### PR TITLE
Bump reqwest 0.11 to 0.12 to fix macOS sandbox panic

### DIFF
--- a/recipe/bump-reqwest.patch
+++ b/recipe/bump-reqwest.patch
@@ -1,0 +1,911 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index b6545349c..b4ab8a877 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -28,7 +28,7 @@ dependencies = [
+  "once_cell",
+  "serde",
+  "version_check",
+- "zerocopy",
++ "zerocopy 0.7.32",
+ ]
+
+ [[package]]
+@@ -165,7 +165,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -176,7 +176,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -215,6 +215,12 @@ version = "0.21.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
++[[package]]
++name = "base64"
++version = "0.22.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
++
+ [[package]]
+ name = "beef"
+ version = "0.5.2"
+@@ -312,6 +318,12 @@ version = "1.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
++[[package]]
++name = "cfg_aliases"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
++
+ [[package]]
+ name = "ciborium"
+ version = "0.2.2"
+@@ -379,7 +391,7 @@ dependencies = [
+  "heck",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -588,15 +600,6 @@ version = "1.10.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+-[[package]]
+-name = "encoding_rs"
+-version = "0.8.34"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+-dependencies = [
+- "cfg-if",
+-]
+-
+ [[package]]
+ name = "equator"
+ version = "0.2.2"
+@@ -614,7 +617,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -770,7 +773,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -851,25 +854,6 @@ dependencies = [
+  "regex-syntax 0.8.5",
+ ]
+
+-[[package]]
+-name = "h2"
+-version = "0.3.26"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+-dependencies = [
+- "bytes",
+- "fnv",
+- "futures-core",
+- "futures-sink",
+- "futures-util",
+- "http",
+- "indexmap",
+- "slab",
+- "tokio",
+- "tokio-util",
+- "tracing",
+-]
+-
+ [[package]]
+ name = "half"
+ version = "2.4.1"
+@@ -910,87 +894,113 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+ [[package]]
+ name = "http"
+-version = "0.2.12"
++version = "1.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
++checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+ dependencies = [
+  "bytes",
+- "fnv",
+  "itoa",
+ ]
+
+ [[package]]
+ name = "http-body"
+-version = "0.4.6"
++version = "1.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
++checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+ dependencies = [
+  "bytes",
+  "http",
+- "pin-project-lite",
+ ]
+
+ [[package]]
+-name = "httparse"
+-version = "1.8.0"
++name = "http-body-util"
++version = "0.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
++checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
++dependencies = [
++ "bytes",
++ "futures-core",
++ "http",
++ "http-body",
++ "pin-project-lite",
++]
+
+ [[package]]
+-name = "httpdate"
+-version = "1.0.3"
++name = "httparse"
++version = "1.10.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
++checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+ [[package]]
+ name = "hyper"
+-version = "0.14.30"
++version = "1.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
++checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+ dependencies = [
+  "bytes",
+  "futures-channel",
+- "futures-core",
+  "futures-util",
+- "h2",
+  "http",
+  "http-body",
+  "httparse",
+- "httpdate",
+  "itoa",
+  "pin-project-lite",
+- "socket2",
++ "smallvec",
+  "tokio",
+- "tower-service",
+- "tracing",
+  "want",
+ ]
+
+ [[package]]
+ name = "hyper-rustls"
+-version = "0.24.2"
++version = "0.27.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
++checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+ dependencies = [
+- "futures-util",
+  "http",
+  "hyper",
++ "hyper-util",
+  "rustls",
++ "rustls-pki-types",
+  "tokio",
+  "tokio-rustls",
++ "tower-service",
++ "webpki-roots 1.0.6",
+ ]
+
+ [[package]]
+ name = "hyper-tls"
+-version = "0.5.0"
++version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
++checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+ dependencies = [
+  "bytes",
++ "http-body-util",
+  "hyper",
++ "hyper-util",
+  "native-tls",
+  "tokio",
+  "tokio-native-tls",
++ "tower-service",
++]
++
++[[package]]
++name = "hyper-util"
++version = "0.1.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
++dependencies = [
++ "bytes",
++ "futures-channel",
++ "futures-util",
++ "http",
++ "http-body",
++ "hyper",
++ "pin-project-lite",
++ "socket2",
++ "tokio",
++ "tower",
++ "tower-service",
++ "tracing",
+ ]
+
+ [[package]]
+@@ -1106,7 +1116,7 @@ checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+ dependencies = [
+  "ahash",
+  "anyhow",
+- "base64",
++ "base64 0.21.7",
+  "bytecount",
+  "fancy-regex",
+  "fraction",
+@@ -1495,7 +1505,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -1560,6 +1570,26 @@ version = "2.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
++[[package]]
++name = "pin-project"
++version = "1.1.10"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
++dependencies = [
++ "pin-project-internal",
++]
++
++[[package]]
++name = "pin-project-internal"
++version = "1.1.10"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.116",
++]
++
+ [[package]]
+ name = "pin-project-lite"
+ version = "0.2.13"
+@@ -1632,7 +1662,16 @@ dependencies = [
+  "smallvec",
+  "symbolic-demangle",
+  "tempfile",
+- "thiserror",
++ "thiserror 1.0.57",
++]
++
++[[package]]
++name = "ppv-lite86"
++version = "0.2.21"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
++dependencies = [
++ "zerocopy 0.8.27",
+ ]
+
+ [[package]]
+@@ -1647,9 +1686,9 @@ dependencies = [
+
+ [[package]]
+ name = "proc-macro2"
+-version = "1.0.78"
++version = "1.0.106"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
++checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+ dependencies = [
+  "unicode-ident",
+ ]
+@@ -1663,6 +1702,58 @@ dependencies = [
+  "memchr",
+ ]
+
++[[package]]
++name = "quinn"
++version = "0.11.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
++dependencies = [
++ "bytes",
++ "pin-project-lite",
++ "quinn-proto",
++ "quinn-udp",
++ "rustc-hash 2.1.1",
++ "rustls",
++ "socket2",
++ "thiserror 2.0.18",
++ "tokio",
++ "tracing",
++]
++
++[[package]]
++name = "quinn-proto"
++version = "0.11.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
++dependencies = [
++ "bytes",
++ "getrandom",
++ "rand",
++ "ring",
++ "rustc-hash 2.1.1",
++ "rustls",
++ "rustls-pki-types",
++ "slab",
++ "thiserror 2.0.18",
++ "tinyvec",
++ "tracing",
++ "web-time",
++]
++
++[[package]]
++name = "quinn-udp"
++version = "0.5.14"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
++dependencies = [
++ "cfg_aliases",
++ "libc",
++ "once_cell",
++ "socket2",
++ "tracing",
++ "windows-sys 0.52.0",
++]
++
+ [[package]]
+ name = "quote"
+ version = "1.0.35"
+@@ -1672,6 +1763,36 @@ dependencies = [
+  "proc-macro2",
+ ]
+
++[[package]]
++name = "rand"
++version = "0.8.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
++dependencies = [
++ "libc",
++ "rand_chacha",
++ "rand_core",
++]
++
++[[package]]
++name = "rand_chacha"
++version = "0.3.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
++dependencies = [
++ "ppv-lite86",
++ "rand_core",
++]
++
++[[package]]
++name = "rand_core"
++version = "0.6.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
++dependencies = [
++ "getrandom",
++]
++
+ [[package]]
+ name = "rayon"
+ version = "1.8.1"
+@@ -1747,21 +1868,21 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+ [[package]]
+ name = "reqwest"
+-version = "0.11.27"
++version = "0.12.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
++checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+ dependencies = [
+- "base64",
++ "base64 0.22.1",
+  "bytes",
+- "encoding_rs",
+  "futures-core",
+  "futures-util",
+- "h2",
+  "http",
+  "http-body",
++ "http-body-util",
+  "hyper",
+  "hyper-rustls",
+  "hyper-tls",
++ "hyper-util",
+  "ipnet",
+  "js-sys",
+  "log",
+@@ -1770,13 +1891,14 @@ dependencies = [
+  "once_cell",
+  "percent-encoding",
+  "pin-project-lite",
++ "quinn",
+  "rustls",
+  "rustls-pemfile",
++ "rustls-pki-types",
+  "serde",
+  "serde_json",
+  "serde_urlencoded",
+  "sync_wrapper",
+- "system-configuration",
+  "tokio",
+  "tokio-native-tls",
+  "tokio-rustls",
+@@ -1785,7 +1907,7 @@ dependencies = [
+  "wasm-bindgen",
+  "wasm-bindgen-futures",
+  "web-sys",
+- "webpki-roots",
++ "webpki-roots 0.26.11",
+  "winreg",
+ ]
+
+@@ -1821,7 +1943,7 @@ dependencies = [
+  "countme",
+  "hashbrown",
+  "memoffset",
+- "rustc-hash",
++ "rustc-hash 1.1.0",
+  "text-size",
+ ]
+
+@@ -1837,6 +1959,12 @@ version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
++[[package]]
++name = "rustc-hash"
++version = "2.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
++
+ [[package]]
+ name = "rustix"
+ version = "0.38.31"
+@@ -1852,32 +1980,45 @@ dependencies = [
+
+ [[package]]
+ name = "rustls"
+-version = "0.21.12"
++version = "0.23.36"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
++checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+ dependencies = [
+- "log",
++ "once_cell",
+  "ring",
++ "rustls-pki-types",
+  "rustls-webpki",
+- "sct",
++ "subtle",
++ "zeroize",
+ ]
+
+ [[package]]
+ name = "rustls-pemfile"
+-version = "1.0.4"
++version = "2.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
++dependencies = [
++ "rustls-pki-types",
++]
++
++[[package]]
++name = "rustls-pki-types"
++version = "1.14.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
++checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+ dependencies = [
+- "base64",
++ "web-time",
++ "zeroize",
+ ]
+
+ [[package]]
+ name = "rustls-webpki"
+-version = "0.101.7"
++version = "0.103.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
++checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+ dependencies = [
+  "ring",
++ "rustls-pki-types",
+  "untrusted",
+ ]
+
+@@ -1942,16 +2083,6 @@ version = "1.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+-[[package]]
+-name = "sct"
+-version = "0.7.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+-dependencies = [
+- "ring",
+- "untrusted",
+-]
+-
+ [[package]]
+ name = "security-framework"
+ version = "2.9.2"
+@@ -2012,7 +2143,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -2046,7 +2177,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -2139,6 +2270,12 @@ version = "0.11.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
++[[package]]
++name = "subtle"
++version = "2.6.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
++
+ [[package]]
+ name = "symbolic-common"
+ version = "12.10.0"
+@@ -2175,9 +2312,9 @@ dependencies = [
+
+ [[package]]
+ name = "syn"
+-version = "2.0.48"
++version = "2.0.116"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
++checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -2186,30 +2323,9 @@ dependencies = [
+
+ [[package]]
+ name = "sync_wrapper"
+-version = "0.1.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+-
+-[[package]]
+-name = "system-configuration"
+-version = "0.5.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+-dependencies = [
+- "bitflags 1.3.2",
+- "core-foundation",
+- "system-configuration-sys",
+-]
+-
+-[[package]]
+-name = "system-configuration-sys"
+-version = "0.5.0"
++version = "1.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+-dependencies = [
+- "core-foundation-sys",
+- "libc",
+-]
++checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+ [[package]]
+ name = "tap"
+@@ -2236,7 +2352,7 @@ dependencies = [
+  "schemars",
+  "serde",
+  "serde_json",
+- "thiserror",
++ "thiserror 1.0.57",
+  "time",
+  "toml",
+  "tracing",
+@@ -2304,7 +2420,7 @@ dependencies = [
+  "sha1",
+  "tap",
+  "taplo",
+- "thiserror",
++ "thiserror 1.0.57",
+  "time",
+  "tokio",
+  "tracing",
+@@ -2401,7 +2517,16 @@ version = "1.0.57"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+ dependencies = [
+- "thiserror-impl",
++ "thiserror-impl 1.0.57",
++]
++
++[[package]]
++name = "thiserror"
++version = "2.0.18"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
++dependencies = [
++ "thiserror-impl 2.0.18",
+ ]
+
+ [[package]]
+@@ -2412,7 +2537,18 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
++]
++
++[[package]]
++name = "thiserror-impl"
++version = "2.0.18"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -2507,7 +2643,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -2522,27 +2658,14 @@ dependencies = [
+
+ [[package]]
+ name = "tokio-rustls"
+-version = "0.24.1"
++version = "0.26.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
++checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+ dependencies = [
+  "rustls",
+  "tokio",
+ ]
+
+-[[package]]
+-name = "tokio-util"
+-version = "0.7.11"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+-dependencies = [
+- "bytes",
+- "futures-core",
+- "futures-sink",
+- "pin-project-lite",
+- "tokio",
+-]
+-
+ [[package]]
+ name = "toml"
+ version = "0.7.8"
+@@ -2577,6 +2700,27 @@ dependencies = [
+  "winnow",
+ ]
+
++[[package]]
++name = "tower"
++version = "0.4.13"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
++dependencies = [
++ "futures-core",
++ "futures-util",
++ "pin-project",
++ "pin-project-lite",
++ "tokio",
++ "tower-layer",
++ "tower-service",
++]
++
++[[package]]
++name = "tower-layer"
++version = "0.3.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
++
+ [[package]]
+ name = "tower-service"
+ version = "0.3.2"
+@@ -2602,7 +2746,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+ ]
+
+ [[package]]
+@@ -2787,7 +2931,7 @@ dependencies = [
+  "log",
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+  "wasm-bindgen-shared",
+ ]
+
+@@ -2821,7 +2965,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
+  "wasm-bindgen-backend",
+  "wasm-bindgen-shared",
+ ]
+@@ -2845,11 +2989,33 @@ dependencies = [
+  "wasm-bindgen",
+ ]
+
++[[package]]
++name = "web-time"
++version = "1.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
++dependencies = [
++ "js-sys",
++ "wasm-bindgen",
++]
++
++[[package]]
++name = "webpki-roots"
++version = "0.26.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
++dependencies = [
++ "webpki-roots 1.0.6",
++]
++
+ [[package]]
+ name = "webpki-roots"
+-version = "0.25.4"
++version = "1.0.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
++checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
++dependencies = [
++ "rustls-pki-types",
++]
+
+ [[package]]
+ name = "winapi"
+@@ -3025,9 +3191,9 @@ dependencies = [
+
+ [[package]]
+ name = "winreg"
+-version = "0.50.0"
++version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
++checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+ dependencies = [
+  "cfg-if",
+  "windows-sys 0.48.0",
+@@ -3039,7 +3205,16 @@ version = "0.7.32"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+ dependencies = [
+- "zerocopy-derive",
++ "zerocopy-derive 0.7.32",
++]
++
++[[package]]
++name = "zerocopy"
++version = "0.8.27"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
++dependencies = [
++ "zerocopy-derive 0.8.27",
+ ]
+
+ [[package]]
+@@ -3050,5 +3225,22 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+- "syn 2.0.48",
++ "syn 2.0.116",
++]
++
++[[package]]
++name = "zerocopy-derive"
++version = "0.8.27"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.116",
+ ]
++
++[[package]]
++name = "zeroize"
++version = "1.8.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+diff --git a/Cargo.toml b/Cargo.toml
+index d98197ccd..e62695e35 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -30,7 +30,7 @@ lsp-types          = { version = "0.93.0" }
+ once_cell          = { version = "1.4" }
+ parking_lot        = { version = "0.12.0" }
+ regex              = { version = "1.5" }
+-reqwest            = { version = "0.11.9", default-features = false }
++reqwest            = { version = "0.12", default-features = false }
+ rowan              = { version = "0.15.3" }
+ schemars           = { version = "0.8.3" }
+ serde              = { version = "1" }

--- a/recipe/bump-reqwest.patch
+++ b/recipe/bump-reqwest.patch
@@ -1,3 +1,20 @@
+From 00f4e92e8e5fb4f9006825b434607e6666357482 Mon Sep 17 00:00:00 2001
+From: Oliver Borchert <oliver.borchert@quantco.com>
+Date: Wed, 18 Feb 2026 00:17:20 +0100
+Subject: [PATCH] fix: bump reqwest from 0.11 to 0.12 to fix macOS panic
+
+reqwest 0.11 depends on system-configuration 0.5.1 which panics when
+SCDynamicStoreCreate returns NULL (e.g. in sandboxed environments).
+reqwest 0.12 drops this dependency entirely when built without the
+macos-system-configuration feature (which is the case here since
+default-features = false).
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+---
+ Cargo.lock | 486 +++++++++++++++++++++++++++++++++++++----------------
+ Cargo.toml |   2 +-
+ 2 files changed, 340 insertions(+), 148 deletions(-)
+
 diff --git a/Cargo.lock b/Cargo.lock
 index b6545349c..b4ab8a877 100644
 --- a/Cargo.lock
@@ -9,7 +26,7 @@ index b6545349c..b4ab8a877 100644
 - "zerocopy",
 + "zerocopy 0.7.32",
  ]
-
+ 
  [[package]]
 @@ -165,7 +165,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
  dependencies = [
@@ -18,7 +35,7 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -176,7 +176,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
  dependencies = [
@@ -27,12 +44,12 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -215,6 +215,12 @@ version = "0.21.7"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
+ 
 +[[package]]
 +name = "base64"
 +version = "0.22.1"
@@ -45,7 +62,7 @@ index b6545349c..b4ab8a877 100644
 @@ -312,6 +318,12 @@ version = "1.0.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
+ 
 +[[package]]
 +name = "cfg_aliases"
 +version = "0.2.1"
@@ -62,12 +79,12 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -588,15 +600,6 @@ version = "1.10.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
-
+ 
 -[[package]]
 -name = "encoding_rs"
 -version = "0.8.34"
@@ -87,7 +104,7 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -770,7 +773,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
  dependencies = [
@@ -96,12 +113,12 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -851,25 +854,6 @@ dependencies = [
   "regex-syntax 0.8.5",
  ]
-
+ 
 -[[package]]
 -name = "h2"
 -version = "0.3.26"
@@ -125,7 +142,7 @@ index b6545349c..b4ab8a877 100644
  name = "half"
  version = "2.4.1"
 @@ -910,87 +894,113 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
+ 
  [[package]]
  name = "http"
 -version = "0.2.12"
@@ -138,7 +155,7 @@ index b6545349c..b4ab8a877 100644
 - "fnv",
   "itoa",
  ]
-
+ 
  [[package]]
  name = "http-body"
 -version = "0.4.6"
@@ -151,7 +168,7 @@ index b6545349c..b4ab8a877 100644
   "http",
 - "pin-project-lite",
  ]
-
+ 
  [[package]]
 -name = "httparse"
 -version = "1.8.0"
@@ -167,7 +184,7 @@ index b6545349c..b4ab8a877 100644
 + "http-body",
 + "pin-project-lite",
 +]
-
+ 
  [[package]]
 -name = "httpdate"
 -version = "1.0.3"
@@ -176,7 +193,7 @@ index b6545349c..b4ab8a877 100644
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 +checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
+ 
  [[package]]
  name = "hyper"
 -version = "0.14.30"
@@ -203,7 +220,7 @@ index b6545349c..b4ab8a877 100644
 - "tracing",
   "want",
  ]
-
+ 
  [[package]]
  name = "hyper-rustls"
 -version = "0.24.2"
@@ -223,7 +240,7 @@ index b6545349c..b4ab8a877 100644
 + "tower-service",
 + "webpki-roots 1.0.6",
  ]
-
+ 
  [[package]]
  name = "hyper-tls"
 -version = "0.5.0"
@@ -261,7 +278,7 @@ index b6545349c..b4ab8a877 100644
 + "tower-service",
 + "tracing",
  ]
-
+ 
  [[package]]
 @@ -1106,7 +1116,7 @@ checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
  dependencies = [
@@ -279,12 +296,12 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -1560,6 +1570,26 @@ version = "2.3.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
+ 
 +[[package]]
 +name = "pin-project"
 +version = "1.1.10"
@@ -324,10 +341,10 @@ index b6545349c..b4ab8a877 100644
 +dependencies = [
 + "zerocopy 0.8.27",
  ]
-
+ 
  [[package]]
 @@ -1647,9 +1686,9 @@ dependencies = [
-
+ 
  [[package]]
  name = "proc-macro2"
 -version = "1.0.78"
@@ -341,7 +358,7 @@ index b6545349c..b4ab8a877 100644
 @@ -1663,6 +1702,58 @@ dependencies = [
   "memchr",
  ]
-
+ 
 +[[package]]
 +name = "quinn"
 +version = "0.11.6"
@@ -400,7 +417,7 @@ index b6545349c..b4ab8a877 100644
 @@ -1672,6 +1763,36 @@ dependencies = [
   "proc-macro2",
  ]
-
+ 
 +[[package]]
 +name = "rand"
 +version = "0.8.5"
@@ -435,7 +452,7 @@ index b6545349c..b4ab8a877 100644
  name = "rayon"
  version = "1.8.1"
 @@ -1747,21 +1868,21 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
+ 
  [[package]]
  name = "reqwest"
 -version = "0.11.27"
@@ -485,7 +502,7 @@ index b6545349c..b4ab8a877 100644
 + "webpki-roots 0.26.11",
   "winreg",
  ]
-
+ 
 @@ -1821,7 +1943,7 @@ dependencies = [
   "countme",
   "hashbrown",
@@ -494,11 +511,11 @@ index b6545349c..b4ab8a877 100644
 + "rustc-hash 1.1.0",
   "text-size",
  ]
-
+ 
 @@ -1837,6 +1959,12 @@ version = "1.1.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
+ 
 +[[package]]
 +name = "rustc-hash"
 +version = "2.1.1"
@@ -509,7 +526,7 @@ index b6545349c..b4ab8a877 100644
  name = "rustix"
  version = "0.38.31"
 @@ -1852,32 +1980,45 @@ dependencies = [
-
+ 
  [[package]]
  name = "rustls"
 -version = "0.21.12"
@@ -527,7 +544,7 @@ index b6545349c..b4ab8a877 100644
 + "subtle",
 + "zeroize",
  ]
-
+ 
  [[package]]
  name = "rustls-pemfile"
 -version = "1.0.4"
@@ -549,7 +566,7 @@ index b6545349c..b4ab8a877 100644
 + "web-time",
 + "zeroize",
  ]
-
+ 
  [[package]]
  name = "rustls-webpki"
 -version = "0.101.7"
@@ -562,11 +579,11 @@ index b6545349c..b4ab8a877 100644
 + "rustls-pki-types",
   "untrusted",
  ]
-
+ 
 @@ -1942,16 +2083,6 @@ version = "1.2.0"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
+ 
 -[[package]]
 -name = "sct"
 -version = "0.7.1"
@@ -587,7 +604,7 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -2046,7 +2177,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
  dependencies = [
@@ -596,12 +613,12 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -2139,6 +2270,12 @@ version = "0.11.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
+ 
 +[[package]]
 +name = "subtle"
 +version = "2.6.1"
@@ -612,7 +629,7 @@ index b6545349c..b4ab8a877 100644
  name = "symbolic-common"
  version = "12.10.0"
 @@ -2175,9 +2312,9 @@ dependencies = [
-
+ 
  [[package]]
  name = "syn"
 -version = "2.0.48"
@@ -624,7 +641,7 @@ index b6545349c..b4ab8a877 100644
   "proc-macro2",
   "quote",
 @@ -2186,30 +2323,9 @@ dependencies = [
-
+ 
  [[package]]
  name = "sync_wrapper"
 -version = "0.1.2"
@@ -653,7 +670,7 @@ index b6545349c..b4ab8a877 100644
 - "libc",
 -]
 +checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-
+ 
  [[package]]
  name = "tap"
 @@ -2236,7 +2352,7 @@ dependencies = [
@@ -690,7 +707,7 @@ index b6545349c..b4ab8a877 100644
 +dependencies = [
 + "thiserror-impl 2.0.18",
  ]
-
+ 
  [[package]]
 @@ -2412,7 +2537,18 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
  dependencies = [
@@ -710,7 +727,7 @@ index b6545349c..b4ab8a877 100644
 + "quote",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -2507,7 +2643,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
  dependencies = [
@@ -719,10 +736,10 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -2522,27 +2658,14 @@ dependencies = [
-
+ 
  [[package]]
  name = "tokio-rustls"
 -version = "0.24.1"
@@ -734,7 +751,7 @@ index b6545349c..b4ab8a877 100644
   "rustls",
   "tokio",
  ]
-
+ 
 -[[package]]
 -name = "tokio-util"
 -version = "0.7.11"
@@ -754,7 +771,7 @@ index b6545349c..b4ab8a877 100644
 @@ -2577,6 +2700,27 @@ dependencies = [
   "winnow",
  ]
-
+ 
 +[[package]]
 +name = "tower"
 +version = "0.4.13"
@@ -786,7 +803,7 @@ index b6545349c..b4ab8a877 100644
 - "syn 2.0.48",
 + "syn 2.0.116",
  ]
-
+ 
  [[package]]
 @@ -2787,7 +2931,7 @@ dependencies = [
   "log",
@@ -796,7 +813,7 @@ index b6545349c..b4ab8a877 100644
 + "syn 2.0.116",
   "wasm-bindgen-shared",
  ]
-
+ 
 @@ -2821,7 +2965,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
  dependencies = [
   "proc-macro2",
@@ -809,7 +826,7 @@ index b6545349c..b4ab8a877 100644
 @@ -2845,11 +2989,33 @@ dependencies = [
   "wasm-bindgen",
  ]
-
+ 
 +[[package]]
 +name = "web-time"
 +version = "1.1.0"
@@ -839,11 +856,11 @@ index b6545349c..b4ab8a877 100644
 +dependencies = [
 + "rustls-pki-types",
 +]
-
+ 
  [[package]]
  name = "winapi"
 @@ -3025,9 +3191,9 @@ dependencies = [
-
+ 
  [[package]]
  name = "winreg"
 -version = "0.50.0"
@@ -870,7 +887,7 @@ index b6545349c..b4ab8a877 100644
 +dependencies = [
 + "zerocopy-derive 0.8.27",
  ]
-
+ 
  [[package]]
 @@ -3050,5 +3225,22 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
  dependencies = [

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,9 +11,11 @@ package:
 source:
   url: https://github.com/tamasfe/taplo/archive/refs/tags/release-taplo-cli-${{ version }}.tar.gz
   sha256: eaec8435bfb5ccd89f7b4dd09385b6be25c2ff00aa25417cb82c88a59d4ccde0
+  patches:
+    - bump-reqwest.patch
 
 build:
-  number: 1
+  number: 2
   script:
     file: build-taplo
 


### PR DESCRIPTION
See https://github.com/tamasfe/taplo/pull/848: `taplo` currently crashes when used inside a `claude` sandbox.

---

## Summary

- Applies the patch from https://github.com/tamasfe/taplo/pull/848 to bump `reqwest` from 0.11 to 0.12
- Fixes a panic on macOS when `SCDynamicStoreCreate` returns `NULL` in sandboxed environments (e.g. Claude Code)
- Bumps build number from 1 to 2

## Details

`reqwest` 0.11 unconditionally depends on `system-configuration` 0.5.1 on macOS for reading system proxy settings. In sandboxed environments where the `configd` daemon is not accessible, `SCDynamicStoreCreate` returns `NULL`, causing a panic. Bumping to `reqwest` 0.12 avoids this because `system-configuration` is no longer pulled in when `default-features = false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)